### PR TITLE
Add a hyphened approach to indicate versioning at Lyft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ metastore_db/
 out/
 target/
 TempStatsStore/
+transportable-udfs-*/bin/
+transportable-udfs-test/transportable-udfs-test-*/bin/

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 # Version of the produced binaries.
 # The version is inferred by shipkit-auto-version Gradle plugin (https://github.com/shipkit/shipkit-auto-version)
-version=0.0.75.0
+version=0.0.75-0


### PR DESCRIPTION
**Why static versioning?**

- Transport uses [shipkit](https://github.com/shipkit/shipkit-auto-version/) for semver. However, shipkit picks the latest version to be merged from git tag command which would not work in our CI builds.

**Format of versioning**

- \<Major\>.\<Minor\>.\<Patch\> refers to actual version pointing to Transport. \<Major\>.\<Minor\>.\<Patch\>-\<internal-version-at-lyft\> the number followed by patch through hyphen indicates the version and edits made on Lyft side. Since Transport strictly adheres to [SEMVER 2](https://semver.org/) guidance, it does not provide scope for another dot delimited identifier for versioning within lyft (which we have been using for other projects like Hive).